### PR TITLE
user profile: correctly load profiles from user directory

### DIFF
--- a/freckles/utils.py
+++ b/freckles/utils.py
@@ -52,6 +52,7 @@ def find_supported_profiles():
     files = os.listdir(DEFAULT_PROFILES_PATH)
     profiles = [f for f in files if os.path.isdir(os.path.join(DEFAULT_PROFILES_PATH, f)) and not f.startswith(".")]
 
+    files = os.listdir(DEFAULT_USER_PROFILES_PATH)
     if os.path.exists(DEFAULT_USER_PROFILES_PATH):
         user_profiles = [f for f in files if os.path.isdir(os.path.join(DEFAULT_USER_PROFILES_PATH, f)) and not f.startswith(".")]
     else:


### PR DESCRIPTION
I think this feature should allow to load any arbitrary profile, and not only profile from freckle core. So files must be recalculated in profile user folder.